### PR TITLE
fixed KeyError issue with lower case letters

### DIFF
--- a/Python_lesson_6_mod_31.py
+++ b/Python_lesson_6_mod_31.py
@@ -15,7 +15,7 @@ def name_flower_dict(filename):
     flower_dict = {}
     with open('/Users/gabe_ung/Desktop/flowers.txt', 'r') as f: # open file: flowers.txt
         for line in f:
-            letter, flower = line.strip().split(':') # split the line where there is a ':'
+            letter, flower = line.strip().lower().split(':') # split the line where there is a ':'
             flower_dict[letter] = flower.strip() # build dictionary with key (letter), value (flower) from file: flowers.txt
     return flower_dict
 
@@ -24,7 +24,7 @@ def name_flower_dict(filename):
 def main():
     the_flower_dict = name_flower_dict('/Users/gabe_ung/Desktop/flowers.txt')
     full_name = input("Please enter your first [space] last name only: ")
-    first_name = full_name[0]
+    first_name = full_name[0].lower()
     first_letter = first_name[0]
     # prints output from user with value for corresponding key (letter) in flower_dict dictionary
     print("Unique flower name with the first letter: {}".format(the_flower_dict[first_letter]))


### PR DESCRIPTION
Remember dictionaries are unordered structures, you cannot call a key-value pair item by location it must be called by value.

You must call the key (letter) to call the value (flower).  For this code to work for both upper and lower case convert the flowers.txt file to a dictionary and use .lower() to convert the capital letters in the file to lower case letters.

letter, flower = line.strip().lower().split(':')

Then do the same for name input:

first_letter = full_name[0].lower()
