### PR TITLE
Removed list comprehension for remove newline

### DIFF
--- a/useful_automation_scripts/standardise_mac_address.py
+++ b/useful_automation_scripts/standardise_mac_address.py
@@ -12,17 +12,17 @@ def main():
     input_file = "mac_addresses.txt" # enter the path to your file here
     with open(input_file, 'r') as in_f:
         for line in in_f.readlines():
-            mac_address.append(line)
+            mac_address.append(line.strip())
 
     # convert mac addresses to desired format e.g. MM-MM-MM-SS-SS-SS to MM:MM:MM:SS:SS:SS
     # replace "-" with ":"
     mac_no_dash = [mac.replace('-', ':') for mac in mac_address] # edit this to suit your desired mac address format
   
     # remove new line ("\n")
-    mac_remove_newline = [mac.replace('\n', '') for mac in mac_no_dash]
+    #mac_remove_newline = [mac.replace('\n', '') for mac in mac_no_dash]
     
     # convert capital to lowercase
-    desired_mac_format = [mac.lower() for mac in mac_remove_newline] # convert to lowercase, edit this to suit your desired mac address format
+    desired_mac_format = [mac.lower() for mac in mac_no_dash] # convert to lowercase, edit this to suit your desired mac address format
     
     # write new mac address format to new text file
     # if output file hasn't already been created a new output file will be created


### PR DESCRIPTION
Add line.strip() to 1st for loop, thus mac_remove_newline loop not needed